### PR TITLE
Change `last-clicked` to `attribution-credit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ The most recent matching impression is given an `attibution-credit` of value 100
 
 For each matching impression, schedule a report. To schedule a report,
 the browser will store the 
- {reporting domain, addestination domain, impression data, [decoded](#metadata-encoding) conversion-metadata, attribution_credit} for the impression.
+ {reporting domain, addestination domain, impression data, [decoded](#metadata-encoding) conversion-metadata, attribution-credit} for the impression.
 Scheduled reports will be sent as detailed in [Sending scheduled reports](#sending-scheduled-reports).
 
 Each impression is only allowed to schedule a maximum of three reports
@@ -236,7 +236,7 @@ To provide additional utility, the user-agent can choose to provide additional a
 
 The default attribution model will be last-click attribution, giving the last-clicked impression for a given conversion event all of the credit.
 
-To remain flexible, the user-agent sends an `attribution_credit` of value 0 to 100 for all conversion reports associated with a single conversion event. This represents the percent of attribution an impression received for a conversion. The sum of credits across a set of reports for one conversion event should equal 100.
+To remain flexible, the user-agent sends an `attribution-credit` of value 0 to 100 for all conversion reports associated with a single conversion event. This represents the percent of attribution an impression received for a conversion. The sum of credits across a set of reports for one conversion event should equal 100.
 
 There are many possible alternatives to this,
 like providing a choice of rules-based attribution models. However, it
@@ -308,7 +308,7 @@ To send a report, the user agent will make a non-credentialed secure
 HTTP POST request to:
 
 ```
-https://reportingdomain/.well-known/register-conversion?impression-data=&conversion-data=&attribution_credit=
+https://reportingdomain/.well-known/register-conversion?impression-data=&conversion-data=&attribution-credit=
 ```
 
 The conversion report data is included as query params as they represent
@@ -318,7 +318,7 @@ non-hierarchical data ([URI RFC](https://tools.ietf.org/html/rfc3986#section-3.4
 
 -   `conversion-metadata`: 3 bit metadata set in the conversion redirect
 
--   `attribution_credit`: integer in range [0, 100], denotes the percentage of credit this impression received for the given conversion. If a conversion only had one matching impression, this will be 100.
+-   `attribution-credit`: integer in range [0, 100], denotes the percentage of credit this impression received for the given conversion. If a conversion only had one matching impression, this will be 100.
 
 The advertiser site’s eTLD+1 will be added as the Referrer. Note that it
 might be useful to advertise which metadata limits were used in the

--- a/README.md
+++ b/README.md
@@ -230,11 +230,13 @@ will delete all impressions that have scheduled three reports.
 ### Multiple impressions for the same conversion (Multi-touch)
 
 If there are multiple impressions that were clicked and lead to a single
-conversion, send conversion reports for all of them.
+conversion, send conversion reports for all of them. 
 
-To remain flexible, the API sends an `attribution_credit` of value 0 to 100 for all conversion reports associated with a single conversion event. The sum of these credits should equal 100.
+To provide additional utility, the user-agent can choose to provide additional annotations to each of these reports, attributing credits for the conversion to them individually. Attribution models allow for more sophisticated, accurate conversion measurement.
 
-The default attribution model will give the last-clicked impression the full attribution_credit.
+The default attribution model will be last-click attribution, giving the last-clicked impression for a given conversion event all of the credit.
+
+To remain flexible, the user-agent sends an `attribution_credit` of value 0 to 100 for all conversion reports associated with a single conversion event. This represents the percent of attribution an impression received for a conversion. The sum of credits across a set of reports for one conversion event should equal 100.
 
 There are many possible alternatives to this,
 like providing a choice of rules-based attribution models. However, it
@@ -306,7 +308,7 @@ To send a report, the user agent will make a non-credentialed secure
 HTTP POST request to:
 
 ```
-https://reportingdomain/.well-known/register-conversion?impression-data=&conversion-data=&last-clicked=
+https://reportingdomain/.well-known/register-conversion?impression-data=&conversion-data=&attribution_credit=
 ```
 
 The conversion report data is included as query params as they represent
@@ -316,7 +318,7 @@ non-hierarchical data ([URI RFC](https://tools.ietf.org/html/rfc3986#section-3.4
 
 -   `conversion-metadata`: 3 bit metadata set in the conversion redirect
 
--   `last-clicked`: true or false, denotes whether this impression was the last clicked impression that led to this conversion
+-   `attribution_credit`: integer in range [0, 100], denotes the percentage of credit this impression received for the given conversion. If a conversion only had one matching impression, this will be 100.
 
 The advertiser site’s eTLD+1 will be added as the Referrer. Note that it
 might be useful to advertise which metadata limits were used in the
@@ -406,7 +408,7 @@ sent. The conversion report is associated with the 7 day deadline as the
 2 day deadline has passed. Roughly 5 days later, `ad-tech.com` receives
 the following HTTP POST:
 ```
-https://ad-tech.com/.well-known/register-conversion?impression-data=12345678&conversion-metadata=2&last-click=true
+https://ad-tech.com/.well-known/register-conversion?impression-data=12345678&conversion-metadata=2&attribution-credit=100
 ```
 
 Privacy Considerations

--- a/README.md
+++ b/README.md
@@ -215,13 +215,11 @@ When the user agent receives a conversion registration on a URL matching
 the addestination eTLD+1, it looks up all impressions in storage that
 match <reporting-domain, addestination>.
 
-The most recent matching impression is given a `last-clicked` attribute of
-true. All other matching impressions are given a `last-clicked` value of
-false.
+The most recent matching impression is given an `attibution-credit` of value 100. All other matching impressions are given an `attibution-credit` of value of 0.
 
 For each matching impression, schedule a report. To schedule a report,
 the browser will store the 
- {reporting domain, addestination domain, impression data, [decoded](#metadata-encoding) conversion-metadata, last-clicked attribute} for the impression.
+ {reporting domain, addestination domain, impression data, [decoded](#metadata-encoding) conversion-metadata, attribution_credit} for the impression.
 Scheduled reports will be sent as detailed in [Sending scheduled reports](#sending-scheduled-reports).
 
 Each impression is only allowed to schedule a maximum of three reports
@@ -232,12 +230,15 @@ will delete all impressions that have scheduled three reports.
 ### Multiple impressions for the same conversion (Multi-touch)
 
 If there are multiple impressions that were clicked and lead to a single
-conversion, send conversion reports for all of them, but label the
-last-clicked one as such. There are many possible alternatives to this,
-like providing a choice of rules-based attribution models. However, it
-isn’t clear the benefits outweigh the additional complexity.
+conversion, send conversion reports for all of them.
 
-Additionally, models other than last-click potentially leak more
+To remain flexible, the API sends an `attribution_credit` of value 0 to 100 for all conversion reports associated with a single conversion event. The sum of these credits should equal 100.
+
+The default attribution model will give the last-clicked impression the full attribution_credit.
+
+There are many possible alternatives to this,
+like providing a choice of rules-based attribution models. However, it
+isn’t clear the benefits outweigh the additional complexity. Additionally, models other than last-click potentially leak more
 cross-site information if impressions are clicked across different
 sites.
 


### PR DESCRIPTION
This change replaces the `last-clicked` attribute in the explainer with `attribution_credit`, and provides some additional context this more flexible attribution model.