### PR TITLE
Mention randomized response in the metadata section

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,11 @@ sophisticated attackers will therefore need to invoke the API many times
 (through many clicks) to join identity between sites with high
 confidence.
 
+Note that this noise still allows for aggregate measurement of bucket sizes
+with an unbiased estimator. See generic approaches of dealing with
+[Randomized response](https://en.wikipedia.org/wiki/Randomized_response) for
+a starting point.
+
 Conversion Delay 
 -----------------
 


### PR DESCRIPTION
Mention that the original frequencies can be recovered in aggregate (followup from issue #24 )